### PR TITLE
test preaudit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,19 @@
 [workspace]
-members = ["packages/*","contracts/*"]
+members = ["packages/*", "contracts/*"]
 
 [workspace.package]
-version = "0.2.1"
-edition = "2021"
-authors = ["Marc <marc@yieldmos.com>"]
+version    = "0.2.1"
+edition    = "2021"
+authors    = ["Marc <marc@yieldmos.com>"]
 repository = "https://github.com/yieldmos/ac-outpost"
 
 
 [workspace.dependencies]
 cosmwasm-schema = "1.1.3"
-cosmwasm-std = {version="1.1.3", default-features = false, features = ["stargate", "staking"]}
+cosmwasm-std = { version = "1.1.3", default-features = false, features = [
+  "stargate",
+  "staking",
+] }
 cosmwasm-storage = "1.1.3"
 cw-storage-plus = "1.0.1"
 cw-multi-test = "0.16.2"
@@ -19,36 +22,44 @@ schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 semver = "1"
-cosmos-sdk-proto = {version="0.17", default-features = false, features=["cosmwasm"]}
+cosmos-sdk-proto = { version = "0.17", default-features = false, features = [
+  "cosmwasm",
+] }
 cw20 = "1.0.1"
-cw20-stake = {git = "https://github.com/DA0-DA0/dao-contracts.git", tag="v2.1.0", features=["library"]}
-cw20-vesting = {package="cw20-vesting", git="https://github.com/wynddao/wynddao.git", tag="v1.6.0"}
-wyndex = {git = "https://github.com/wynddao/wynddex.git", tag="v2.0.3"}
-wyndex-multi-hop = {git = "https://github.com/wynddao/wynddex.git", tag="v2.0.3", features=["library"]}
-wynd-stake = {git = "https://github.com/wynddao/wynddao.git", tag="v1.6.0", features=["library"]}
-wyndex-factory = { git = "https://github.com/wynddao/wynddex.git", tag="v2.0.3"}
+cw20-stake = { git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v2.1.0", features = [
+  "library",
+] }
+cw20-vesting = { package = "cw20-vesting", git = "https://github.com/wynddao/wynddao.git", tag = "v1.6.0" }
+wyndex = { git = "https://github.com/wynddao/wynddex.git", tag = "v2.0.3" }
+wyndex-multi-hop = { git = "https://github.com/wynddao/wynddex.git", tag = "v2.0.3", features = [
+  "library",
+] }
+wynd-stake = { git = "https://github.com/wynddao/wynddao.git", tag = "v1.6.0", features = [
+  "library",
+] }
+wyndex-factory = { git = "https://github.com/wynddao/wynddex.git", tag = "v2.0.3" }
 # wynd-utils = {git="https://github.com/wynddao/wynddao.git", tag="v1.6.0"}
-outpost-utils = {path="./packages/utils"}
-wynd-helpers = {path="./packages/wynd-helpers"}
-wyndex-stake = { git = "https://github.com/wynddao/wynddex.git", tag="v2.0.3"}
+outpost-utils = { path = "./packages/utils" }
+wynd-helpers  = { path = "./packages/wynd-helpers" }
+wyndex-stake  = { git = "https://github.com/wynddao/wynddex.git", tag = "v2.0.3" }
 
 [profile.release.package.ymos-junostake-outpost]
 codegen-units = 1
-incremental = false
+incremental   = false
 
 [profile.release.package.ymos-wyndstake-outpost]
 codegen-units = 1
-incremental = false
+incremental   = false
 
 [profile.release.package.ymos-wyndlp-outpost]
 codegen-units = 1
-incremental = false
+incremental   = false
 
 
 [profile.release]
-rpath = false
-lto = true
-overflow-checks = true
-opt-level = 3
-debug = false
+rpath            = false
+lto              = true
+overflow-checks  = true
+opt-level        = 3
+debug            = false
 debug-assertions = false


### PR DESCRIPTION
tested contracts/*

SUMMARY
===
coverage: ❌ 11.68% coverage, 152/1301 lines covered
linter: error: could not compile `outpost-utils` due to 2 previous errors
fmt: error
ai-pr-review: summary and walkthrough generated
ai-audit: *processing, still in progress*

COVERAGE DETAILS
===
|| Uncovered Lines:
|| contracts/junostake/src/bin/junostake_schema.rs: 5-9
|| contracts/junostake/src/contract.rs: 41-44, 56-58, 60-61, 63, 67, 73-76, 78-81, 83-86, 89-90, 94, 96-98, 100-103, 105-107, 110, 113-115, 120-122, 124
|| contracts/junostake/src/error.rs: 44-45
|| contracts/junostake/src/execute.rs: 44, 52, 55, 59-63, 67, 71-76, 80, 82, 86, 99, 101-104, 113-114, 118, 120-126, 128, 132-135, 137-143, 145-150, 152, 154-155, 159-161, 165-172, 174-177, 184, 186, 188, 264, 281, 284-285, 289-293, 298-300, 305, 307-313, 316, 320, 327, 334-335, 338-345, 348-352
|| contracts/junostake/src/helpers.rs: 14-15, 18-23, 25
|| contracts/junostake/src/queries.rs: 17, 19, 23-26, 34, 40-41, 45, 47-52, 54, 59, 63-67, 70, 74, 79-83, 85, 87, 91, 96-100, 102, 104
|| contracts/wyndlp/src/bin/wyndlp_schema.rs: 5-9
|| contracts/wyndlp/src/contract.rs: 36, 38-39, 41-46, 49, 53, 57-59, 61-62, 64, 68, 74-75, 77-78, 81-84, 87-90, 93-94, 98, 100, 102-103, 106-109, 112-114, 117, 120-123, 125-131, 137-139, 142
|| contracts/wyndlp/src/error.rs: 57-58
|| contracts/wyndlp/src/execute.rs: 60, 63-64, 68, 72-76, 80-82, 86-87, 90, 92-93, 101, 103, 119-125, 127, 131-132, 135, 137, 142, 146-149, 152-160, 167-168, 172-173, 175-177, 181-190, 195-200, 202-204, 206-209, 212-216, 221, 223, 225, 230, 236, 239, 242-248, 254, 257, 265-266, 269-273, 277-283, 286, 289, 291, 294, 301-302, 305-309, 313-319, 321, 324, 326, 329, 337-338, 341-345, 349-353, 355, 358, 360, 364, 373-376, 381-386, 390-395, 398-403, 406-410, 418-424, 426-427, 432, 436-440, 447, 449-455, 458, 462, 467, 475-476, 479-486, 489-493, 500, 506, 510, 512, 516-518, 520-521, 526-528, 531, 533, 535-537, 539-546, 553-555, 558, 560, 562-564, 566-573, 579, 583-585, 588, 590-591, 594-596, 599-604, 607-614, 620, 624-626, 629, 631-633, 636-641, 644-648, 653
|| contracts/wyndlp/src/helpers.rs: 22-23, 26-31, 33, 39-40, 42-44, 46-47, 49, 51, 53, 56, 59-60, 62-66, 70-72, 85, 90, 92, 95, 97, 99-100, 102-105, 107-110, 112
|| contracts/wyndlp/src/queries.rs: 13, 15, 19-22, 30, 34-38, 42, 46, 51-55, 57, 62, 67-70, 74-75, 77, 80-81, 85, 90, 95-98, 102, 104, 106-108, 112
|| contracts/wyndstake/src/bin/wyndstake_schema.rs: 5-9
|| contracts/wyndstake/src/contract.rs: 36, 38-39, 41-46, 49, 53, 57-59, 61-62, 64, 68, 74-75, 77-78, 81-84, 87-90, 93-94, 98, 100, 102-103, 106-109, 112-114, 117, 120-122, 127-129, 131
|| contracts/wyndstake/src/error.rs: 47-48
|| contracts/wyndstake/src/execute.rs: 38, 46, 49, 53-57, 61, 65-69, 73, 75, 79, 88-94, 96, 101-102, 106, 108-115, 119-121, 123, 126-132, 135, 137-141, 144-145, 148-150, 154-164, 171, 173, 175, 178, 184-189, 204-216, 219, 223-229, 231, 234, 248-251, 253-254, 258-262, 264, 267, 271, 287, 290-291, 295-299, 304-306, 310, 312-318, 321, 325, 332, 339-340, 343-350, 353-357
|| contracts/wyndstake/src/helpers.rs: 14-15, 18-23, 25
|| contracts/wyndstake/src/queries.rs: 19, 21, 25-28, 36, 40-43, 47, 51, 56-60, 62, 64, 68, 73-76, 78-80, 85-91, 95
|| packages/utils/src/comp_prefs.rs: 57-58, 60-61, 75-80, 88-94, 129, 136, 143-144, 146
|| packages/utils/src/helpers.rs: 10-11, 13-15, 40-43, 45-49, 53-55, 64-66, 68-69, 77, 84-87, 91
|| packages/utils/src/msg_gen.rs: 22-29, 62-63, 65-66, 72-73, 83, 89, 91, 98-99, 104, 108, 110, 114, 118-120
|| packages/wynd-helpers/src/wynd_lp.rs: 81-82, 129, 135, 138, 140, 145, 148, 152-154, 156-158, 161, 168, 170, 173-180, 182, 186
|| packages/wynd-helpers/src/wynd_swap.rs: 13, 20-23, 56, 58-70, 73, 83, 91-94, 97, 99, 105, 111, 113-121, 123-124, 127-129, 132, 139, 143-145, 151, 159, 167-168, 172, 174-175, 177-183, 187, 189-195, 197, 205, 214-215, 220, 224-225, 227-233, 237, 241-242, 244-250, 254, 256-262, 264, 268-270, 283, 290, 292-299, 304-309, 313-316
|| Tested/Total Lines:
|| contracts/junostake/src/bin/junostake_schema.rs: 0/5
|| contracts/junostake/src/contract.rs: 7/51
|| contracts/junostake/src/error.rs: 0/2
|| contracts/junostake/src/execute.rs: 30/140
|| contracts/junostake/src/helpers.rs: 0/9
|| contracts/junostake/src/queries.rs: 0/40
|| contracts/wyndlp/src/bin/wyndlp_schema.rs: 0/5
|| contracts/wyndlp/src/contract.rs: 0/59
|| contracts/wyndlp/src/error.rs: 0/2
|| contracts/wyndlp/src/execute.rs: 0/300
|| contracts/wyndlp/src/helpers.rs: 21/67
|| contracts/wyndlp/src/queries.rs: 0/42
|| contracts/wyndstake/src/bin/wyndstake_schema.rs: 0/5
|| contracts/wyndstake/src/contract.rs: 0/51
|| contracts/wyndstake/src/error.rs: 0/2
|| contracts/wyndstake/src/execute.rs: 0/153
|| contracts/wyndstake/src/helpers.rs: 0/9
|| contracts/wyndstake/src/queries.rs: 0/36
|| packages/utils/src/comp_prefs.rs: 3/25
|| packages/utils/src/helpers.rs: 11/39
|| packages/utils/src/msg_gen.rs: 6/32
|| packages/wynd-helpers/src/wynd_lp.rs: 56/83
|| packages/wynd-helpers/src/wynd_swap.rs: 18/144
|| 
11.68% coverage, 152/1301 lines covered

LINTER DETAILS
===
```
error: this `if` statement can be collapsed
  --> packages/utils/src/helpers.rs:84:5
   |
84 | /     if sender.ne(delegator) {
85 | |         if sender.ne(&admin.load(deps.storage)?) {
86 | |             if !authorized_addrs.load(deps.storage)?.contains(sender) {
87 | |                 return Err(OutpostError::UnauthorizedCompounder(sender.to_string()));
88 | |             }
89 | |         }
90 | |     }
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
   = note: `-D clippy::collapsible-if` implied by `-D warnings`
help: collapse nested if block
   |
84 ~     if sender.ne(delegator) && sender.ne(&admin.load(deps.storage)?) {
85 +         if !authorized_addrs.load(deps.storage)?.contains(sender) {
86 +             return Err(OutpostError::UnauthorizedCompounder(sender.to_string()));
87 +         }
88 +     }
   |

error: this `if` statement can be collapsed
  --> packages/utils/src/helpers.rs:85:9
   |
85 | /         if sender.ne(&admin.load(deps.storage)?) {
86 | |             if !authorized_addrs.load(deps.storage)?.contains(sender) {
87 | |                 return Err(OutpostError::UnauthorizedCompounder(sender.to_string()));
88 | |             }
89 | |         }
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: collapse nested if block
   |
85 ~         if sender.ne(&admin.load(deps.storage)?) && !authorized_addrs.load(deps.storage)?.contains(sender) {
86 +             return Err(OutpostError::UnauthorizedCompounder(sender.to_string()));
87 +         }
   |

    Checking wyndex-factory v2.0.3 (https://github.com/wynddao/wynddex.git?tag=v2.0.3#25130c21)
error: could not compile `outpost-utils` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `outpost-utils` due to 2 previous errors
```

FMT DETAILS
===
```
error[internal]: left behind trailing whitespace
   --> /Users/john/llm/tmp/ac-outpost/contracts/wyndstake/src/execute.rs:114:114:56
    |
114 |                          query_wynd_juno_swap(&querier, 
    |                                                        ^
    |
```
